### PR TITLE
feat: configure Jest testing framework with coverage and watch modes

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,9 @@
     "dev": "ts-node src/index.ts",
     "watch": "tsc --watch",
     "prepublishOnly": "npm run build",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "jest",
+    "test:watch": "jest --watch",
+    "test:cov": "jest --coverage"
   },
   "dependencies": {
     "@nestjs/common": "^11.0.1",
@@ -79,6 +81,12 @@
       "**/*.(t|j)s"
     ],
     "coverageDirectory": "../coverage",
-    "testEnvironment": "node"
+    "testEnvironment": "node",
+    "transformIgnorePatterns": [
+      "node_modules/(?!(ora|chalk|chalk-template|cli-spinners|cli-cursor|log-symbols|strip-ansi|ansi-regex|is-interactive|is-unicode-supported|string-width|emoji-regex|ansi-styles)/)"
+    ],
+    "moduleNameMapper": {
+      "^(\\.{1,2}/.*)\\.js$": "$1"
+    }
   }
 }

--- a/src/__mocks__/chalk.ts
+++ b/src/__mocks__/chalk.ts
@@ -1,0 +1,12 @@
+const chalk = {
+  red: jest.fn((text: string) => text),
+  green: jest.fn((text: string) => text),
+  yellow: jest.fn((text: string) => text),
+  blue: jest.fn((text: string) => text),
+  cyan: jest.fn((text: string) => text),
+  white: jest.fn((text: string) => text),
+  gray: jest.fn((text: string) => text),
+  bold: jest.fn((text: string) => text),
+};
+
+export default chalk;

--- a/src/__mocks__/inquirer.ts
+++ b/src/__mocks__/inquirer.ts
@@ -1,0 +1,7 @@
+const mockPrompt = jest.fn();
+
+const inquirer = {
+  prompt: mockPrompt,
+};
+
+export default inquirer;

--- a/src/__mocks__/ora.ts
+++ b/src/__mocks__/ora.ts
@@ -1,0 +1,16 @@
+const ora = jest.fn(() => ({
+  start: jest.fn().mockReturnThis(),
+  succeed: jest.fn().mockReturnThis(),
+  fail: jest.fn().mockReturnThis(),
+  warn: jest.fn().mockReturnThis(),
+  info: jest.fn().mockReturnThis(),
+  stop: jest.fn().mockReturnThis(),
+  clear: jest.fn().mockReturnThis(),
+  render: jest.fn().mockReturnThis(),
+  frame: jest.fn().mockReturnThis(),
+  text: '',
+  color: 'cyan',
+  isSpinning: false,
+}));
+
+export default ora;

--- a/src/services/__tests__/file-generator.service.spec.ts
+++ b/src/services/__tests__/file-generator.service.spec.ts
@@ -1,0 +1,370 @@
+import fs from 'fs-extra';
+import path from 'path';
+import { FileGeneratorService } from '../file-generator.service';
+import { ProjectConfig } from '../../types/project.types';
+import { PackageManager, Database } from '../../constants/enums';
+import { DockerComposeGenerator } from '../../generators/docker-compose.generator';
+import { GitHubActionsGenerator } from '../../generators/github-actions.generator';
+import { ConfigFilesGenerator } from '../../generators/config-files.generator';
+import { EnvGenerator } from '../../generators/env.generator';
+import * as packageJsonTemplate from '../../templates/package-json.template';
+import * as tsconfigTemplate from '../../templates/tsconfig.template';
+import * as mainTemplate from '../../templates/main.template';
+import * as appModuleTemplate from '../../templates/app-module.template';
+import * as appControllerTemplate from '../../templates/app-controller.template';
+import * as appServiceTemplate from '../../templates/app-service.template';
+import * as appControllerSpecTemplate from '../../templates/app-controller.spec.template';
+import * as appServiceSpecTemplate from '../../templates/app-service.spec.template';
+import * as appE2ESpecTemplate from '../../templates/app-e2e-spec.template';
+import * as jestE2EConfigTemplate from '../../templates/jest-e2e-config.template';
+import * as readmeTemplate from '../../templates/readme.template';
+
+jest.mock('fs-extra');
+jest.mock('../../generators/docker-compose.generator');
+jest.mock('../../generators/github-actions.generator');
+jest.mock('../../generators/config-files.generator');
+jest.mock('../../generators/env.generator');
+jest.mock('../../templates/package-json.template');
+jest.mock('../../templates/tsconfig.template');
+jest.mock('../../templates/main.template');
+jest.mock('../../templates/app-module.template');
+jest.mock('../../templates/app-controller.template');
+jest.mock('../../templates/app-service.template');
+jest.mock('../../templates/app-controller.spec.template');
+jest.mock('../../templates/app-service.spec.template');
+jest.mock('../../templates/app-e2e-spec.template');
+jest.mock('../../templates/jest-e2e-config.template');
+jest.mock('../../templates/readme.template');
+
+describe('FileGeneratorService', () => {
+  const mockConfig: ProjectConfig = {
+    name: 'test-project',
+    path: '/test/path',
+    answers: {
+      description: 'Test description',
+      author: 'Test Author',
+      packageManager: PackageManager.NPM,
+      useSwagger: true,
+      useDocker: true,
+      database: Database.POSTGRES,
+      useGitHubActions: true,
+    },
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('generateBaseFiles', () => {
+    it('should generate package.json with correct parameters', () => {
+      const mockPackageJson = '{"name": "test"}';
+      (packageJsonTemplate.createPackageJson as jest.Mock).mockReturnValue(
+        mockPackageJson,
+      );
+
+      FileGeneratorService.generateBaseFiles(mockConfig);
+
+      expect(packageJsonTemplate.createPackageJson).toHaveBeenCalledWith(
+        'test-project',
+        'Test description',
+        'Test Author',
+        true,
+      );
+      expect(fs.writeFileSync).toHaveBeenCalledWith(
+        '/test/path/package.json',
+        mockPackageJson,
+      );
+    });
+
+    it('should generate tsconfig.json', () => {
+      const mockTsConfig = '{"compilerOptions": {}}';
+      (tsconfigTemplate.createTsConfig as jest.Mock).mockReturnValue(
+        mockTsConfig,
+      );
+
+      FileGeneratorService.generateBaseFiles(mockConfig);
+
+      expect(tsconfigTemplate.createTsConfig).toHaveBeenCalled();
+      expect(fs.writeFileSync).toHaveBeenCalledWith(
+        '/test/path/tsconfig.json',
+        mockTsConfig,
+      );
+    });
+
+    it('should generate tsconfig.build.json with correct configuration', () => {
+      FileGeneratorService.generateBaseFiles(mockConfig);
+
+      expect(fs.writeFileSync).toHaveBeenCalledWith(
+        '/test/path/tsconfig.build.json',
+        expect.stringContaining('"extends": "./tsconfig.json"'),
+      );
+      expect(fs.writeFileSync).toHaveBeenCalledWith(
+        '/test/path/tsconfig.build.json',
+        expect.stringContaining('"exclude"'),
+      );
+    });
+  });
+
+  describe('generateSourceFiles', () => {
+    it('should generate main.ts with swagger configuration', () => {
+      const mockMainTs = 'main content';
+      (mainTemplate.createMainTs as jest.Mock).mockReturnValue(mockMainTs);
+
+      FileGeneratorService.generateSourceFiles(mockConfig);
+
+      expect(mainTemplate.createMainTs).toHaveBeenCalledWith(true);
+      expect(fs.writeFileSync).toHaveBeenCalledWith(
+        '/test/path/src/main.ts',
+        mockMainTs,
+      );
+    });
+
+    it('should generate app.module.ts', () => {
+      const mockAppModule = 'module content';
+      (appModuleTemplate.createAppModule as jest.Mock).mockReturnValue(
+        mockAppModule,
+      );
+
+      FileGeneratorService.generateSourceFiles(mockConfig);
+
+      expect(appModuleTemplate.createAppModule).toHaveBeenCalled();
+      expect(fs.writeFileSync).toHaveBeenCalledWith(
+        '/test/path/src/app.module.ts',
+        mockAppModule,
+      );
+    });
+
+    it('should generate app.controller.ts', () => {
+      const mockController = 'controller content';
+      (appControllerTemplate.createAppController as jest.Mock).mockReturnValue(
+        mockController,
+      );
+
+      FileGeneratorService.generateSourceFiles(mockConfig);
+
+      expect(appControllerTemplate.createAppController).toHaveBeenCalled();
+      expect(fs.writeFileSync).toHaveBeenCalledWith(
+        '/test/path/src/app.controller.ts',
+        mockController,
+      );
+    });
+
+    it('should generate app.service.ts', () => {
+      const mockService = 'service content';
+      (appServiceTemplate.createAppService as jest.Mock).mockReturnValue(
+        mockService,
+      );
+
+      FileGeneratorService.generateSourceFiles(mockConfig);
+
+      expect(appServiceTemplate.createAppService).toHaveBeenCalled();
+      expect(fs.writeFileSync).toHaveBeenCalledWith(
+        '/test/path/src/app.service.ts',
+        mockService,
+      );
+    });
+
+    it('should generate test files', () => {
+      const mockControllerSpec = 'controller spec';
+      const mockServiceSpec = 'service spec';
+      (
+        appControllerSpecTemplate.createAppControllerSpec as jest.Mock
+      ).mockReturnValue(mockControllerSpec);
+      (
+        appServiceSpecTemplate.createAppServiceSpec as jest.Mock
+      ).mockReturnValue(mockServiceSpec);
+
+      FileGeneratorService.generateSourceFiles(mockConfig);
+
+      expect(
+        appControllerSpecTemplate.createAppControllerSpec,
+      ).toHaveBeenCalled();
+      expect(appServiceSpecTemplate.createAppServiceSpec).toHaveBeenCalled();
+      expect(fs.writeFileSync).toHaveBeenCalledWith(
+        '/test/path/src/app.controller.spec.ts',
+        mockControllerSpec,
+      );
+      expect(fs.writeFileSync).toHaveBeenCalledWith(
+        '/test/path/src/app.service.spec.ts',
+        mockServiceSpec,
+      );
+    });
+  });
+
+  describe('generateTestFiles', () => {
+    it('should create test directory', () => {
+      FileGeneratorService.generateTestFiles(mockConfig);
+
+      expect(fs.ensureDirSync).toHaveBeenCalledWith('/test/path/test');
+    });
+
+    it('should generate e2e test file', () => {
+      const mockE2ESpec = 'e2e spec content';
+      (appE2ESpecTemplate.createAppE2ESpec as jest.Mock).mockReturnValue(
+        mockE2ESpec,
+      );
+
+      FileGeneratorService.generateTestFiles(mockConfig);
+
+      expect(appE2ESpecTemplate.createAppE2ESpec).toHaveBeenCalled();
+      expect(fs.writeFileSync).toHaveBeenCalledWith(
+        '/test/path/test/app.e2e-spec.ts',
+        mockE2ESpec,
+      );
+    });
+
+    it('should generate jest e2e config', () => {
+      const mockJestConfig = '{"preset": "ts-jest"}';
+      (jestE2EConfigTemplate.createJestE2EConfig as jest.Mock).mockReturnValue(
+        mockJestConfig,
+      );
+
+      FileGeneratorService.generateTestFiles(mockConfig);
+
+      expect(jestE2EConfigTemplate.createJestE2EConfig).toHaveBeenCalled();
+      expect(fs.writeFileSync).toHaveBeenCalledWith(
+        '/test/path/test/jest-e2e.json',
+        mockJestConfig,
+      );
+    });
+  });
+
+  describe('generateEnvironmentFiles', () => {
+    it('should generate environment files using EnvGenerator', () => {
+      const mockEnvFiles = {
+        '.env': 'ENV_VAR=value',
+        '.env.example': 'ENV_VAR=',
+      };
+      (EnvGenerator.generate as jest.Mock).mockReturnValue(mockEnvFiles);
+
+      FileGeneratorService.generateEnvironmentFiles(mockConfig);
+
+      expect(EnvGenerator.generate).toHaveBeenCalledWith(mockConfig);
+      expect(fs.writeFileSync).toHaveBeenCalledWith(
+        '/test/path/.env',
+        'ENV_VAR=value',
+      );
+      expect(fs.writeFileSync).toHaveBeenCalledWith(
+        '/test/path/.env.example',
+        'ENV_VAR=',
+      );
+    });
+  });
+
+  describe('generateConfigFiles', () => {
+    it('should generate config files using ConfigFilesGenerator', () => {
+      const mockConfigFiles = {
+        '.eslintrc.js': 'module.exports = {}',
+        '.prettierrc': '{}',
+      };
+      (ConfigFilesGenerator.generate as jest.Mock).mockReturnValue(
+        mockConfigFiles,
+      );
+
+      FileGeneratorService.generateConfigFiles(mockConfig);
+
+      expect(ConfigFilesGenerator.generate).toHaveBeenCalledWith(mockConfig);
+      expect(fs.writeFileSync).toHaveBeenCalledWith(
+        '/test/path/.eslintrc.js',
+        'module.exports = {}',
+      );
+      expect(fs.writeFileSync).toHaveBeenCalledWith(
+        '/test/path/.prettierrc',
+        '{}',
+      );
+    });
+  });
+
+  describe('generateDockerFiles', () => {
+    it('should generate docker files when useDocker is true', () => {
+      const mockDockerFiles = {
+        'docker-compose.yml': 'version: "3.8"',
+        Dockerfile: 'FROM node:18',
+      };
+      (DockerComposeGenerator.generate as jest.Mock).mockReturnValue(
+        mockDockerFiles,
+      );
+
+      FileGeneratorService.generateDockerFiles(mockConfig);
+
+      expect(DockerComposeGenerator.generate).toHaveBeenCalledWith(mockConfig);
+      expect(fs.writeFileSync).toHaveBeenCalledWith(
+        '/test/path/docker-compose.yml',
+        'version: "3.8"',
+      );
+      expect(fs.writeFileSync).toHaveBeenCalledWith(
+        '/test/path/Dockerfile',
+        'FROM node:18',
+      );
+    });
+
+    it('should not generate docker files when useDocker is false', () => {
+      const configWithoutDocker: ProjectConfig = {
+        ...mockConfig,
+        answers: { ...mockConfig.answers, useDocker: false },
+      };
+
+      FileGeneratorService.generateDockerFiles(configWithoutDocker);
+
+      expect(DockerComposeGenerator.generate).not.toHaveBeenCalled();
+      expect(fs.writeFileSync).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('generateGitHubActionsFiles', () => {
+    it('should generate GitHub Actions workflow when useGitHubActions is true', () => {
+      const mockWorkflow = 'name: Tests\non: push';
+      (
+        GitHubActionsGenerator.generateTestWorkflow as jest.Mock
+      ).mockReturnValue(mockWorkflow);
+
+      FileGeneratorService.generateGitHubActionsFiles(mockConfig);
+
+      expect(fs.ensureDirSync).toHaveBeenCalledWith(
+        '/test/path/.github/workflows',
+      );
+      expect(GitHubActionsGenerator.generateTestWorkflow).toHaveBeenCalledWith(
+        PackageManager.NPM,
+      );
+      expect(fs.writeFileSync).toHaveBeenCalledWith(
+        '/test/path/.github/workflows/tests.yml',
+        mockWorkflow,
+      );
+    });
+
+    it('should not generate GitHub Actions files when useGitHubActions is false', () => {
+      const configWithoutActions: ProjectConfig = {
+        ...mockConfig,
+        answers: { ...mockConfig.answers, useGitHubActions: false },
+      };
+
+      FileGeneratorService.generateGitHubActionsFiles(configWithoutActions);
+
+      expect(
+        GitHubActionsGenerator.generateTestWorkflow,
+      ).not.toHaveBeenCalled();
+      expect(fs.ensureDirSync).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('generateReadme', () => {
+    it('should generate README with all project details', () => {
+      const mockReadme = '# Test Project\n\nDescription';
+      (readmeTemplate.createReadme as jest.Mock).mockReturnValue(mockReadme);
+
+      FileGeneratorService.generateReadme(mockConfig);
+
+      expect(readmeTemplate.createReadme).toHaveBeenCalledWith(
+        'test-project',
+        'Test description',
+        PackageManager.NPM,
+        true,
+        true,
+      );
+      expect(fs.writeFileSync).toHaveBeenCalledWith(
+        '/test/path/README.md',
+        mockReadme,
+      );
+    });
+  });
+});

--- a/src/services/__tests__/git.service.spec.ts
+++ b/src/services/__tests__/git.service.spec.ts
@@ -1,0 +1,154 @@
+import { execSync } from 'child_process';
+import { GitService } from '../git.service';
+
+// Mock modules before importing
+jest.mock('child_process');
+jest.mock('ora');
+
+// Import ora after mocking
+import ora from 'ora';
+
+describe('GitService', () => {
+  let mockSpinner: any;
+  let mockChdir: jest.SpyInstance;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    mockSpinner = {
+      start: jest.fn().mockReturnThis(),
+      succeed: jest.fn().mockReturnThis(),
+      warn: jest.fn().mockReturnThis(),
+      fail: jest.fn().mockReturnThis(),
+    };
+
+    (ora as jest.Mock).mockReturnValue(mockSpinner);
+
+    mockChdir = jest.spyOn(process, 'chdir').mockImplementation();
+  });
+
+  afterEach(() => {
+    mockChdir.mockRestore();
+  });
+
+  describe('initialize', () => {
+    const projectPath = '/test/project/path';
+
+    it('should start spinner with correct message', () => {
+      (execSync as jest.Mock).mockImplementation();
+
+      GitService.initialize(projectPath);
+
+      expect(ora).toHaveBeenCalledWith('Initializing Git repository...');
+      expect(mockSpinner.start).toHaveBeenCalled();
+    });
+
+    it('should change to project directory', () => {
+      (execSync as jest.Mock).mockImplementation();
+
+      GitService.initialize(projectPath);
+
+      expect(process.chdir).toHaveBeenCalledWith(projectPath);
+    });
+
+    it('should execute git init command', () => {
+      (execSync as jest.Mock).mockImplementation();
+
+      GitService.initialize(projectPath);
+
+      expect(execSync).toHaveBeenCalledWith('git init', { stdio: 'ignore' });
+    });
+
+    it('should execute git add command', () => {
+      (execSync as jest.Mock).mockImplementation();
+
+      GitService.initialize(projectPath);
+
+      expect(execSync).toHaveBeenCalledWith('git add .', { stdio: 'ignore' });
+    });
+
+    it('should execute commands in correct order', () => {
+      const executionOrder: string[] = [];
+
+      (execSync as jest.Mock).mockImplementation((command: string) => {
+        executionOrder.push(command);
+      });
+
+      GitService.initialize(projectPath);
+
+      expect(executionOrder).toEqual(['git init', 'git add .']);
+    });
+
+    it('should show success message when git commands succeed', () => {
+      (execSync as jest.Mock).mockImplementation();
+
+      GitService.initialize(projectPath);
+
+      expect(mockSpinner.succeed).toHaveBeenCalledWith(
+        'Git repository initialized with all files staged!',
+      );
+    });
+
+    it('should show warning when git init fails', () => {
+      (execSync as jest.Mock).mockImplementation(() => {
+        throw new Error('git command not found');
+      });
+
+      GitService.initialize(projectPath);
+
+      expect(mockSpinner.warn).toHaveBeenCalledWith(
+        'Git initialization skipped (Git may not be installed)',
+      );
+    });
+
+    it('should show warning when git add fails', () => {
+      (execSync as jest.Mock)
+        .mockImplementationOnce(() => {})
+        .mockImplementationOnce(() => {
+          throw new Error('git add failed');
+        });
+
+      GitService.initialize(projectPath);
+
+      expect(mockSpinner.warn).toHaveBeenCalledWith(
+        'Git initialization skipped (Git may not be installed)',
+      );
+    });
+
+    it('should not throw error when git commands fail', () => {
+      (execSync as jest.Mock).mockImplementation(() => {
+        throw new Error('git not found');
+      });
+
+      expect(() => GitService.initialize(projectPath)).not.toThrow();
+    });
+
+    it('should handle git not installed error gracefully', () => {
+      const gitNotFoundError = new Error('git: command not found');
+      (execSync as jest.Mock).mockImplementation(() => {
+        throw gitNotFoundError;
+      });
+
+      GitService.initialize(projectPath);
+
+      expect(mockSpinner.warn).toHaveBeenCalled();
+      expect(mockSpinner.succeed).not.toHaveBeenCalled();
+    });
+
+    it('should suppress stdio output from git commands', () => {
+      (execSync as jest.Mock).mockImplementation();
+
+      GitService.initialize(projectPath);
+
+      const gitInitCall = (execSync as jest.Mock).mock.calls.find(
+        (call) => call[0] === 'git init',
+      );
+      const gitAddCall = (execSync as jest.Mock).mock.calls.find(
+        (call) => call[0] === 'git add .',
+      );
+
+      expect(gitInitCall?.[1]).toEqual({ stdio: 'ignore' });
+      expect(gitAddCall?.[1]).toEqual({ stdio: 'ignore' });
+    });
+  });
+});

--- a/src/services/__tests__/package-installer.service.spec.ts
+++ b/src/services/__tests__/package-installer.service.spec.ts
@@ -1,0 +1,289 @@
+import { PackageManager } from '../../constants/enums';
+
+jest.mock('child_process');
+jest.mock('ora');
+jest.mock('chalk');
+
+const mockExecAsync = jest.fn();
+
+jest.mock('util', () => ({
+  promisify: jest.fn(() => mockExecAsync),
+}));
+
+import { PackageInstallerService } from '../package-installer.service';
+import ora from 'ora';
+import chalk from 'chalk';
+
+describe('PackageInstallerService', () => {
+  let mockSpinner: any;
+  let mockChdir: jest.SpyInstance;
+  let consoleErrorSpy: jest.SpyInstance;
+  let consoleLogSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    mockSpinner = {
+      start: jest.fn().mockReturnThis(),
+      succeed: jest.fn().mockReturnThis(),
+      fail: jest.fn().mockReturnThis(),
+      warn: jest.fn().mockReturnThis(),
+    };
+
+    (ora as jest.Mock).mockReturnValue(mockSpinner);
+
+    mockChdir = jest.spyOn(process, 'chdir').mockImplementation();
+    consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation();
+    consoleLogSpy = jest.spyOn(console, 'log').mockImplementation();
+  });
+
+  afterEach(() => {
+    mockChdir.mockRestore();
+    consoleErrorSpy.mockRestore();
+    consoleLogSpy.mockRestore();
+  });
+
+  describe('getInstallCommand', () => {
+    it('should return yarn command for YARN package manager', () => {
+      const command = PackageInstallerService.getInstallCommand(
+        PackageManager.YARN,
+      );
+
+      expect(command).toBe('yarn');
+    });
+
+    it('should return pnpm install command for PNPM package manager', () => {
+      const command = PackageInstallerService.getInstallCommand(
+        PackageManager.PNPM,
+      );
+
+      expect(command).toBe('pnpm install');
+    });
+
+    it('should return npm install command for NPM package manager', () => {
+      const command = PackageInstallerService.getInstallCommand(
+        PackageManager.NPM,
+      );
+
+      expect(command).toBe('npm install');
+    });
+
+    it('should return npm install as default for unknown package manager', () => {
+      const command = PackageInstallerService.getInstallCommand(
+        'unknown' as PackageManager,
+      );
+
+      expect(command).toBe('npm install');
+    });
+  });
+
+  describe('install', () => {
+    const projectPath = '/test/project/path';
+
+    it('should start spinner with correct message', async () => {
+      mockExecAsync.mockResolvedValue({ stdout: '', stderr: '' });
+
+      await PackageInstallerService.install(projectPath, PackageManager.NPM);
+
+      expect(ora).toHaveBeenCalledWith('Installing dependencies...');
+      expect(mockSpinner.start).toHaveBeenCalled();
+    });
+
+    it('should change to project directory', async () => {
+      mockExecAsync.mockResolvedValue({ stdout: '', stderr: '' });
+
+      await PackageInstallerService.install(projectPath, PackageManager.NPM);
+
+      expect(process.chdir).toHaveBeenCalledWith(projectPath);
+    });
+
+    it('should execute npm install command with correct options', async () => {
+      mockExecAsync.mockResolvedValue({ stdout: '', stderr: '' });
+
+      await PackageInstallerService.install(projectPath, PackageManager.NPM);
+
+      expect(mockExecAsync).toHaveBeenCalledWith('npm install', {
+        cwd: projectPath,
+        timeout: 300000,
+        env: { ...process.env, NODE_ENV: 'development' },
+      });
+    });
+
+    it('should execute yarn command for YARN package manager', async () => {
+      mockExecAsync.mockResolvedValue({ stdout: '', stderr: '' });
+
+      await PackageInstallerService.install(projectPath, PackageManager.YARN);
+
+      expect(mockExecAsync).toHaveBeenCalledWith('yarn', {
+        cwd: projectPath,
+        timeout: 300000,
+        env: { ...process.env, NODE_ENV: 'development' },
+      });
+    });
+
+    it('should execute pnpm install command for PNPM package manager', async () => {
+      mockExecAsync.mockResolvedValue({ stdout: '', stderr: '' });
+
+      await PackageInstallerService.install(projectPath, PackageManager.PNPM);
+
+      expect(mockExecAsync).toHaveBeenCalledWith('pnpm install', {
+        cwd: projectPath,
+        timeout: 300000,
+        env: { ...process.env, NODE_ENV: 'development' },
+      });
+    });
+
+    it('should show success message when installation succeeds', async () => {
+      mockExecAsync.mockResolvedValue({ stdout: 'success', stderr: '' });
+
+      await PackageInstallerService.install(projectPath, PackageManager.NPM);
+
+      expect(mockSpinner.succeed).toHaveBeenCalledWith(
+        'Dependencies installed successfully!',
+      );
+    });
+
+    it('should handle warnings in stderr without throwing', async () => {
+      mockExecAsync.mockResolvedValue({
+        stdout: '',
+        stderr: 'WARN deprecated package',
+      });
+
+      await PackageInstallerService.install(projectPath, PackageManager.NPM);
+
+      expect(mockSpinner.succeed).toHaveBeenCalledWith(
+        'Dependencies installed successfully!',
+      );
+    });
+
+    it('should throw error when stderr contains ERR!', async () => {
+      mockExecAsync.mockResolvedValue({
+        stdout: '',
+        stderr: 'npm ERR! something went wrong',
+      });
+
+      await expect(
+        PackageInstallerService.install(projectPath, PackageManager.NPM),
+      ).rejects.toThrow('npm ERR! something went wrong');
+
+      expect(mockSpinner.fail).toHaveBeenCalledWith(
+        'Failed to install dependencies',
+      );
+    });
+
+    it('should fail spinner and display error message on installation failure', async () => {
+      const error = new Error('Installation failed');
+      mockExecAsync.mockRejectedValue(error);
+
+      await expect(
+        PackageInstallerService.install(projectPath, PackageManager.NPM),
+      ).rejects.toThrow('Installation failed');
+
+      expect(mockSpinner.fail).toHaveBeenCalledWith(
+        'Failed to install dependencies',
+      );
+    });
+
+    it('should display error details in red when installation fails', async () => {
+      const error = new Error('Network error');
+      mockExecAsync.mockRejectedValue(error);
+
+      try {
+        await PackageInstallerService.install(projectPath, PackageManager.NPM);
+      } catch (e) {
+        // Expected to throw
+      }
+
+      expect(console.error).toHaveBeenCalledWith(
+        chalk.red('\n❌ Installation error:'),
+      );
+      expect(console.error).toHaveBeenCalledWith(chalk.gray('Network error'));
+    });
+
+    it('should display manual installation instructions on failure', async () => {
+      const error = new Error('Installation failed');
+      mockExecAsync.mockRejectedValue(error);
+
+      try {
+        await PackageInstallerService.install(projectPath, PackageManager.NPM);
+      } catch (e) {
+        // Expected to throw
+      }
+
+      expect(console.log).toHaveBeenCalledWith(
+        chalk.yellow('\n⚠️  Project created but dependencies not installed.'),
+      );
+      expect(console.log).toHaveBeenCalledWith(
+        chalk.cyan('\nTo install dependencies manually:'),
+      );
+      expect(console.log).toHaveBeenCalledWith(
+        chalk.white(`  1. cd ${projectPath}`),
+      );
+      expect(console.log).toHaveBeenCalledWith(chalk.white(`  2. npm install`));
+      expect(console.log).toHaveBeenCalledWith(
+        chalk.white(`  3. npm run start:dev\n`),
+      );
+    });
+
+    it('should display correct manual instructions for yarn', async () => {
+      const error = new Error('Installation failed');
+      mockExecAsync.mockRejectedValue(error);
+
+      try {
+        await PackageInstallerService.install(projectPath, PackageManager.YARN);
+      } catch (e) {
+        // Expected to throw
+      }
+
+      expect(console.log).toHaveBeenCalledWith(chalk.white(`  2. yarn`));
+      expect(console.log).toHaveBeenCalledWith(
+        chalk.white(`  3. yarn run start:dev\n`),
+      );
+    });
+
+    it('should display correct manual instructions for pnpm', async () => {
+      const error = new Error('Installation failed');
+      mockExecAsync.mockRejectedValue(error);
+
+      try {
+        await PackageInstallerService.install(projectPath, PackageManager.PNPM);
+      } catch (e) {
+        // Expected to throw
+      }
+
+      expect(console.log).toHaveBeenCalledWith(
+        chalk.white(`  2. pnpm install`),
+      );
+      expect(console.log).toHaveBeenCalledWith(
+        chalk.white(`  3. pnpm run start:dev\n`),
+      );
+    });
+
+    it('should use correct timeout for installation', async () => {
+      mockExecAsync.mockResolvedValue({ stdout: '', stderr: '' });
+
+      await PackageInstallerService.install(projectPath, PackageManager.NPM);
+
+      const callArgs = mockExecAsync.mock.calls[0][1];
+      expect(callArgs.timeout).toBe(300000);
+    });
+
+    it('should set NODE_ENV to development', async () => {
+      mockExecAsync.mockResolvedValue({ stdout: '', stderr: '' });
+
+      await PackageInstallerService.install(projectPath, PackageManager.NPM);
+
+      const callArgs = mockExecAsync.mock.calls[0][1];
+      expect(callArgs.env.NODE_ENV).toBe('development');
+    });
+
+    it('should rethrow error after displaying instructions', async () => {
+      const error = new Error('Installation failed');
+      mockExecAsync.mockRejectedValue(error);
+
+      await expect(
+        PackageInstallerService.install(projectPath, PackageManager.NPM),
+      ).rejects.toThrow(error);
+    });
+  });
+});

--- a/src/services/__tests__/prompts.service.spec.ts
+++ b/src/services/__tests__/prompts.service.spec.ts
@@ -1,0 +1,404 @@
+import { PromptsService } from '../prompts.service';
+import { PackageManager, Database } from '../../constants/enums';
+import { ProjectAnswers } from '../../types/project.types';
+
+jest.mock('inquirer');
+
+import inquirer from 'inquirer';
+
+describe('PromptsService', () => {
+  let mockPrompt: jest.Mock;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockPrompt = inquirer.prompt as unknown as jest.Mock;
+  });
+
+  describe('getProjectDetails', () => {
+    it('should prompt user with all required questions', async () => {
+      const mockAnswers: ProjectAnswers = {
+        packageManager: PackageManager.NPM,
+        description: 'Test app',
+        author: 'Test Author',
+        useDocker: false,
+        useSwagger: true,
+        useGitHubActions: true,
+      };
+
+      mockPrompt.mockResolvedValue(mockAnswers);
+
+      await PromptsService.getProjectDetails();
+
+      expect(mockPrompt).toHaveBeenCalledTimes(1);
+      expect(mockPrompt).toHaveBeenCalledWith(
+        expect.arrayContaining([
+          expect.objectContaining({
+            type: 'list',
+            name: 'packageManager',
+            message: 'Which package manager would you like to use?',
+          }),
+          expect.objectContaining({
+            type: 'input',
+            name: 'description',
+            message: 'Project description:',
+          }),
+          expect.objectContaining({
+            type: 'input',
+            name: 'author',
+            message: 'Author:',
+          }),
+          expect.objectContaining({
+            type: 'confirm',
+            name: 'useDocker',
+            message: 'Add Docker support?',
+          }),
+          expect.objectContaining({
+            type: 'list',
+            name: 'database',
+            message: 'Which database would you like to use with Docker?',
+          }),
+          expect.objectContaining({
+            type: 'confirm',
+            name: 'useSwagger',
+            message: 'Add Swagger documentation?',
+          }),
+          expect.objectContaining({
+            type: 'confirm',
+            name: 'useGitHubActions',
+            message: 'Add GitHub Actions for CI/CD?',
+          }),
+        ]),
+      );
+    });
+
+    it('should return project answers from inquirer', async () => {
+      const mockAnswers: ProjectAnswers = {
+        packageManager: PackageManager.YARN,
+        description: 'My awesome app',
+        author: 'John Doe',
+        useDocker: true,
+        database: Database.POSTGRES,
+        useSwagger: true,
+        useGitHubActions: false,
+      };
+
+      mockPrompt.mockResolvedValue(mockAnswers);
+
+      const result = await PromptsService.getProjectDetails();
+
+      expect(result).toEqual(mockAnswers);
+    });
+
+    it('should use default package manager NPM when none provided', async () => {
+      const mockAnswers: ProjectAnswers = {
+        packageManager: PackageManager.NPM,
+        description: 'Test',
+        author: '',
+        useDocker: false,
+        useSwagger: true,
+        useGitHubActions: true,
+      };
+
+      mockPrompt.mockResolvedValue(mockAnswers);
+
+      await PromptsService.getProjectDetails();
+
+      const promptCall = mockPrompt.mock.calls[0][0];
+      const packageManagerPrompt = promptCall.find(
+        (q: any) => q.name === 'packageManager',
+      );
+
+      expect(packageManagerPrompt.default).toBe(PackageManager.NPM);
+    });
+
+    it('should use provided default package manager', async () => {
+      const mockAnswers: ProjectAnswers = {
+        packageManager: PackageManager.PNPM,
+        description: 'Test',
+        author: '',
+        useDocker: false,
+        useSwagger: true,
+        useGitHubActions: true,
+      };
+
+      mockPrompt.mockResolvedValue(mockAnswers);
+
+      await PromptsService.getProjectDetails(PackageManager.PNPM);
+
+      const promptCall = mockPrompt.mock.calls[0][0];
+      const packageManagerPrompt = promptCall.find(
+        (q: any) => q.name === 'packageManager',
+      );
+
+      expect(packageManagerPrompt.default).toBe(PackageManager.PNPM);
+    });
+
+    it('should include all package manager choices', async () => {
+      const mockAnswers: ProjectAnswers = {
+        packageManager: PackageManager.NPM,
+        description: 'Test',
+        author: '',
+        useDocker: false,
+        useSwagger: true,
+        useGitHubActions: true,
+      };
+
+      mockPrompt.mockResolvedValue(mockAnswers);
+
+      await PromptsService.getProjectDetails();
+
+      const promptCall = mockPrompt.mock.calls[0][0];
+      const packageManagerPrompt = promptCall.find(
+        (q: any) => q.name === 'packageManager',
+      );
+
+      expect(packageManagerPrompt.choices).toEqual(
+        Object.values(PackageManager),
+      );
+    });
+
+    it('should include all database choices', async () => {
+      const mockAnswers: ProjectAnswers = {
+        packageManager: PackageManager.NPM,
+        description: 'Test',
+        author: '',
+        useDocker: false,
+        useSwagger: true,
+        useGitHubActions: true,
+      };
+
+      mockPrompt.mockResolvedValue(mockAnswers);
+
+      await PromptsService.getProjectDetails();
+
+      const promptCall = mockPrompt.mock.calls[0][0];
+      const databasePrompt = promptCall.find((q: any) => q.name === 'database');
+
+      expect(databasePrompt.choices).toEqual(Object.values(Database));
+    });
+
+    it('should set default description to "A NestJS application"', async () => {
+      const mockAnswers: ProjectAnswers = {
+        packageManager: PackageManager.NPM,
+        description: 'A NestJS application',
+        author: '',
+        useDocker: false,
+        useSwagger: true,
+        useGitHubActions: true,
+      };
+
+      mockPrompt.mockResolvedValue(mockAnswers);
+
+      await PromptsService.getProjectDetails();
+
+      const promptCall = mockPrompt.mock.calls[0][0];
+      const descriptionPrompt = promptCall.find(
+        (q: any) => q.name === 'description',
+      );
+
+      expect(descriptionPrompt.default).toBe('A NestJS application');
+    });
+
+    it('should set default author to empty string', async () => {
+      const mockAnswers: ProjectAnswers = {
+        packageManager: PackageManager.NPM,
+        description: 'Test',
+        author: '',
+        useDocker: false,
+        useSwagger: true,
+        useGitHubActions: true,
+      };
+
+      mockPrompt.mockResolvedValue(mockAnswers);
+
+      await PromptsService.getProjectDetails();
+
+      const promptCall = mockPrompt.mock.calls[0][0];
+      const authorPrompt = promptCall.find((q: any) => q.name === 'author');
+
+      expect(authorPrompt.default).toBe('');
+    });
+
+    it('should set useDocker default to false', async () => {
+      const mockAnswers: ProjectAnswers = {
+        packageManager: PackageManager.NPM,
+        description: 'Test',
+        author: '',
+        useDocker: false,
+        useSwagger: true,
+        useGitHubActions: true,
+      };
+
+      mockPrompt.mockResolvedValue(mockAnswers);
+
+      await PromptsService.getProjectDetails();
+
+      const promptCall = mockPrompt.mock.calls[0][0];
+      const dockerPrompt = promptCall.find((q: any) => q.name === 'useDocker');
+
+      expect(dockerPrompt.default).toBe(false);
+    });
+
+    it('should set useSwagger default to true', async () => {
+      const mockAnswers: ProjectAnswers = {
+        packageManager: PackageManager.NPM,
+        description: 'Test',
+        author: '',
+        useDocker: false,
+        useSwagger: true,
+        useGitHubActions: true,
+      };
+
+      mockPrompt.mockResolvedValue(mockAnswers);
+
+      await PromptsService.getProjectDetails();
+
+      const promptCall = mockPrompt.mock.calls[0][0];
+      const swaggerPrompt = promptCall.find(
+        (q: any) => q.name === 'useSwagger',
+      );
+
+      expect(swaggerPrompt.default).toBe(true);
+    });
+
+    it('should set useGitHubActions default to true', async () => {
+      const mockAnswers: ProjectAnswers = {
+        packageManager: PackageManager.NPM,
+        description: 'Test',
+        author: '',
+        useDocker: false,
+        useSwagger: true,
+        useGitHubActions: true,
+      };
+
+      mockPrompt.mockResolvedValue(mockAnswers);
+
+      await PromptsService.getProjectDetails();
+
+      const promptCall = mockPrompt.mock.calls[0][0];
+      const githubActionsPrompt = promptCall.find(
+        (q: any) => q.name === 'useGitHubActions',
+      );
+
+      expect(githubActionsPrompt.default).toBe(true);
+    });
+
+    it('should set database default to MySQL', async () => {
+      const mockAnswers: ProjectAnswers = {
+        packageManager: PackageManager.NPM,
+        description: 'Test',
+        author: '',
+        useDocker: false,
+        useSwagger: true,
+        useGitHubActions: true,
+      };
+
+      mockPrompt.mockResolvedValue(mockAnswers);
+
+      await PromptsService.getProjectDetails();
+
+      const promptCall = mockPrompt.mock.calls[0][0];
+      const databasePrompt = promptCall.find((q: any) => q.name === 'database');
+
+      expect(databasePrompt.default).toBe(Database.MYSQL);
+    });
+
+    it('should only show database prompt when useDocker is true', async () => {
+      const mockAnswers: ProjectAnswers = {
+        packageManager: PackageManager.NPM,
+        description: 'Test',
+        author: '',
+        useDocker: false,
+        useSwagger: true,
+        useGitHubActions: true,
+      };
+
+      mockPrompt.mockResolvedValue(mockAnswers);
+
+      await PromptsService.getProjectDetails();
+
+      const promptCall = mockPrompt.mock.calls[0][0];
+      const databasePrompt = promptCall.find((q: any) => q.name === 'database');
+
+      expect(databasePrompt.when).toBeDefined();
+      expect(databasePrompt.when({ useDocker: false })).toBe(false);
+      expect(databasePrompt.when({ useDocker: true })).toBe(true);
+    });
+
+    it('should handle all package manager options', async () => {
+      for (const pm of Object.values(PackageManager)) {
+        const mockAnswers: ProjectAnswers = {
+          packageManager: pm,
+          description: 'Test',
+          author: '',
+          useDocker: false,
+          useSwagger: true,
+          useGitHubActions: true,
+        };
+
+        mockPrompt.mockResolvedValue(mockAnswers);
+
+        const result = await PromptsService.getProjectDetails();
+
+        expect(result.packageManager).toBe(pm);
+      }
+    });
+
+    it('should handle all database options', async () => {
+      for (const db of Object.values(Database)) {
+        const mockAnswers: ProjectAnswers = {
+          packageManager: PackageManager.NPM,
+          description: 'Test',
+          author: '',
+          useDocker: true,
+          database: db,
+          useSwagger: true,
+          useGitHubActions: true,
+        };
+
+        mockPrompt.mockResolvedValue(mockAnswers);
+
+        const result = await PromptsService.getProjectDetails();
+
+        expect(result.database).toBe(db);
+      }
+    });
+
+    it('should handle Docker disabled scenario', async () => {
+      const mockAnswers: ProjectAnswers = {
+        packageManager: PackageManager.NPM,
+        description: 'Test',
+        author: '',
+        useDocker: false,
+        useSwagger: true,
+        useGitHubActions: true,
+      };
+
+      mockPrompt.mockResolvedValue(mockAnswers);
+
+      const result = await PromptsService.getProjectDetails();
+
+      expect(result.useDocker).toBe(false);
+      expect(result.database).toBeUndefined();
+    });
+
+    it('should handle Docker enabled with database scenario', async () => {
+      const mockAnswers: ProjectAnswers = {
+        packageManager: PackageManager.NPM,
+        description: 'Test',
+        author: '',
+        useDocker: true,
+        database: Database.POSTGRES,
+        useSwagger: true,
+        useGitHubActions: true,
+      };
+
+      mockPrompt.mockResolvedValue(mockAnswers);
+
+      const result = await PromptsService.getProjectDetails();
+
+      expect(result.useDocker).toBe(true);
+      expect(result.database).toBe(Database.POSTGRES);
+    });
+  });
+});


### PR DESCRIPTION
- Replace placeholder test script with Jest test runner
- Add test:watch and test:cov scripts for development workflow
- Configure Jest to handle ES modules and TypeScript transformations
- Add module name mapping for .js file extensions