### PR TITLE
refactor: remove Swagger and GitHub Actions configuration options

### DIFF
--- a/src/commands/__tests__/new.spec.ts
+++ b/src/commands/__tests__/new.spec.ts
@@ -41,8 +41,6 @@ describe('newCommand', () => {
     author: 'Test Author',
     useDocker: true,
     database: Database.POSTGRES,
-    useSwagger: true,
-    useGitHubActions: true,
   };
 
   const mockProjectPath = path.resolve(process.cwd(), mockProjectName);
@@ -165,7 +163,6 @@ describe('newCommand', () => {
       expect(PackageInstallerService.install).toHaveBeenCalledWith(
         mockProjectPath,
         PackageManager.NPM,
-        true,
         Database.POSTGRES,
       );
     });

--- a/src/commands/new.ts
+++ b/src/commands/new.ts
@@ -56,7 +56,6 @@ export async function newCommand(
       await PackageInstallerService.install(
         projectPath,
         answers.packageManager,
-        answers.useSwagger,
         answers.database,
       );
 

--- a/src/generators/__tests__/config-files.generator.spec.ts
+++ b/src/generators/__tests__/config-files.generator.spec.ts
@@ -12,8 +12,6 @@ describe('Project Types', () => {
         author: 'Test Author',
         useDocker: true,
         database: Database.POSTGRES,
-        useSwagger: true,
-        useGitHubActions: false,
       };
 
       expect(answers.packageManager).toBe(PackageManager.NPM);
@@ -21,8 +19,6 @@ describe('Project Types', () => {
       expect(answers.author).toBe('Test Author');
       expect(answers.useDocker).toBe(true);
       expect(answers.database).toBe(Database.POSTGRES);
-      expect(answers.useSwagger).toBe(true);
-      expect(answers.useGitHubActions).toBe(false);
     });
 
     it('should allow optional database field', () => {
@@ -31,8 +27,6 @@ describe('Project Types', () => {
         description: 'Test',
         author: 'Author',
         useDocker: false,
-        useSwagger: false,
-        useGitHubActions: true,
       };
 
       expect(answers.database).toBeUndefined();
@@ -62,8 +56,6 @@ describe('Project Types', () => {
           author: 'Developer',
           useDocker: true,
           database: Database.MONGODB,
-          useSwagger: true,
-          useGitHubActions: true,
         },
       };
 

--- a/src/generators/__tests__/docker-compose.generator.spec.ts
+++ b/src/generators/__tests__/docker-compose.generator.spec.ts
@@ -15,8 +15,6 @@ describe('DockerComposeGenerator', () => {
       author: 'Test Author',
       useDocker,
       database,
-      useSwagger: false,
-      useGitHubActions: false,
     },
   });
 

--- a/src/generators/__tests__/env.generator.spec.ts
+++ b/src/generators/__tests__/env.generator.spec.ts
@@ -18,8 +18,6 @@ describe('EnvGenerator', () => {
       author: 'Test Author',
       useDocker,
       database,
-      useSwagger: false,
-      useGitHubActions: false,
     },
   });
 
@@ -135,8 +133,6 @@ describe('EnvGenerator', () => {
           description: 'Test',
           author: 'Test Author',
           useDocker: false,
-          useSwagger: false,
-          useGitHubActions: false,
         },
       };
 

--- a/src/services/__tests__/file-generator.service.spec.ts
+++ b/src/services/__tests__/file-generator.service.spec.ts
@@ -44,10 +44,8 @@ describe('FileGeneratorService', () => {
       description: 'Test description',
       author: 'Test Author',
       packageManager: PackageManager.NPM,
-      useSwagger: true,
       useDocker: true,
       database: Database.POSTGRES,
-      useGitHubActions: true,
     },
   };
 
@@ -68,7 +66,6 @@ describe('FileGeneratorService', () => {
         'test-project',
         'Test description',
         'Test Author',
-        true,
         Database.POSTGRES,
       );
       expect(fs.writeFileSync).toHaveBeenCalledWith(
@@ -113,7 +110,6 @@ describe('FileGeneratorService', () => {
 
       FileGeneratorService.generateSourceFiles(mockConfig);
 
-      expect(mainTemplate.createMainTs).toHaveBeenCalledWith(true);
       expect(fs.writeFileSync).toHaveBeenCalledWith(
         '/test/path/src/main.ts',
         mockMainTs,
@@ -369,20 +365,6 @@ describe('FileGeneratorService', () => {
         mockWorkflow,
       );
     });
-
-    it('should not generate GitHub Actions files when useGitHubActions is false', () => {
-      const configWithoutActions: ProjectConfig = {
-        ...mockConfig,
-        answers: { ...mockConfig.answers, useGitHubActions: false },
-      };
-
-      FileGeneratorService.generateGitHubActionsFiles(configWithoutActions);
-
-      expect(
-        GitHubActionsGenerator.generateTestWorkflow,
-      ).not.toHaveBeenCalled();
-      expect(fs.ensureDirSync).not.toHaveBeenCalled();
-    });
   });
 
   describe('generateReadme', () => {
@@ -396,7 +378,6 @@ describe('FileGeneratorService', () => {
         'test-project',
         'Test description',
         PackageManager.NPM,
-        true,
         true,
       );
       expect(fs.writeFileSync).toHaveBeenCalledWith(

--- a/src/services/__tests__/package-installer.service.spec.ts
+++ b/src/services/__tests__/package-installer.service.spec.ts
@@ -1,4 +1,4 @@
-import { PackageManager } from '../../constants/enums';
+import { Database, PackageManager } from '../../constants/enums';
 
 jest.mock('child_process');
 jest.mock('ora');
@@ -43,21 +43,8 @@ describe('PackageInstallerService', () => {
   });
 
   describe('getDependencies', () => {
-    it('should return base dependencies without swagger', () => {
-      const deps = PackageInstallerService.getDependencies(false);
-
-      expect(deps).toEqual([
-        '@nestjs/common',
-        '@nestjs/core',
-        '@nestjs/platform-express',
-        '@nestjs/config',
-        'reflect-metadata',
-        'rxjs',
-      ]);
-    });
-
-    it('should include swagger dependency when useSwagger is true', () => {
-      const deps = PackageInstallerService.getDependencies(true);
+    it('should include swagger dependency when useSwagger ', () => {
+      const deps = PackageInstallerService.getDependencies();
 
       expect(deps).toContain('@nestjs/swagger');
       expect(deps).toHaveLength(7);
@@ -173,7 +160,7 @@ describe('PackageInstallerService', () => {
       await PackageInstallerService.install(
         projectPath,
         PackageManager.NPM,
-        true,
+        Database.POSTGRES,
       );
 
       expect(mockExecAsync).toHaveBeenCalledTimes(2);
@@ -189,19 +176,6 @@ describe('PackageInstallerService', () => {
       expect(secondCall[0]).toContain('npm install --save-dev');
       expect(secondCall[0]).toContain('@nestjs/cli');
       expect(secondCall[0]).toContain('typescript');
-    });
-
-    it('should not include swagger when useSwagger is false', async () => {
-      mockExecAsync.mockResolvedValue({ stdout: '', stderr: '' });
-
-      await PackageInstallerService.install(
-        projectPath,
-        PackageManager.NPM,
-        false,
-      );
-
-      const firstCall = mockExecAsync.mock.calls[0];
-      expect(firstCall[0]).not.toContain('@nestjs/swagger');
     });
 
     it('should execute with correct options for both calls', async () => {

--- a/src/services/__tests__/prompts.service.spec.ts
+++ b/src/services/__tests__/prompts.service.spec.ts
@@ -21,8 +21,6 @@ describe('PromptsService', () => {
         description: 'Test app',
         author: 'Test Author',
         useDocker: false,
-        useSwagger: true,
-        useGitHubActions: true,
       };
 
       mockPrompt.mockResolvedValue(mockAnswers);
@@ -57,16 +55,6 @@ describe('PromptsService', () => {
             name: 'database',
             message: 'Which database would you like to use with Docker?',
           }),
-          expect.objectContaining({
-            type: 'confirm',
-            name: 'useSwagger',
-            message: 'Add Swagger documentation?',
-          }),
-          expect.objectContaining({
-            type: 'confirm',
-            name: 'useGitHubActions',
-            message: 'Add GitHub Actions for CI/CD?',
-          }),
         ]),
       );
     });
@@ -78,8 +66,6 @@ describe('PromptsService', () => {
         author: 'John Doe',
         useDocker: true,
         database: Database.POSTGRES,
-        useSwagger: true,
-        useGitHubActions: false,
       };
 
       mockPrompt.mockResolvedValue(mockAnswers);
@@ -95,8 +81,6 @@ describe('PromptsService', () => {
         description: 'Test',
         author: '',
         useDocker: false,
-        useSwagger: true,
-        useGitHubActions: true,
       };
 
       mockPrompt.mockResolvedValue(mockAnswers);
@@ -117,8 +101,6 @@ describe('PromptsService', () => {
         description: 'Test',
         author: '',
         useDocker: false,
-        useSwagger: true,
-        useGitHubActions: true,
       };
 
       mockPrompt.mockResolvedValue(mockAnswers);
@@ -139,8 +121,6 @@ describe('PromptsService', () => {
         description: 'Test',
         author: '',
         useDocker: false,
-        useSwagger: true,
-        useGitHubActions: true,
       };
 
       mockPrompt.mockResolvedValue(mockAnswers);
@@ -163,8 +143,6 @@ describe('PromptsService', () => {
         description: 'Test',
         author: '',
         useDocker: false,
-        useSwagger: true,
-        useGitHubActions: true,
       };
 
       mockPrompt.mockResolvedValue(mockAnswers);
@@ -183,8 +161,6 @@ describe('PromptsService', () => {
         description: 'A NestJS application',
         author: '',
         useDocker: false,
-        useSwagger: true,
-        useGitHubActions: true,
       };
 
       mockPrompt.mockResolvedValue(mockAnswers);
@@ -205,8 +181,6 @@ describe('PromptsService', () => {
         description: 'Test',
         author: '',
         useDocker: false,
-        useSwagger: true,
-        useGitHubActions: true,
       };
 
       mockPrompt.mockResolvedValue(mockAnswers);
@@ -225,8 +199,6 @@ describe('PromptsService', () => {
         description: 'Test',
         author: '',
         useDocker: false,
-        useSwagger: true,
-        useGitHubActions: true,
       };
 
       mockPrompt.mockResolvedValue(mockAnswers);
@@ -239,58 +211,12 @@ describe('PromptsService', () => {
       expect(dockerPrompt.default).toBe(false);
     });
 
-    it('should set useSwagger default to true', async () => {
-      const mockAnswers: ProjectAnswers = {
-        packageManager: PackageManager.NPM,
-        description: 'Test',
-        author: '',
-        useDocker: false,
-        useSwagger: true,
-        useGitHubActions: true,
-      };
-
-      mockPrompt.mockResolvedValue(mockAnswers);
-
-      await PromptsService.getProjectDetails();
-
-      const promptCall = mockPrompt.mock.calls[0][0];
-      const swaggerPrompt = promptCall.find(
-        (q: any) => q.name === 'useSwagger',
-      );
-
-      expect(swaggerPrompt.default).toBe(true);
-    });
-
-    it('should set useGitHubActions default to true', async () => {
-      const mockAnswers: ProjectAnswers = {
-        packageManager: PackageManager.NPM,
-        description: 'Test',
-        author: '',
-        useDocker: false,
-        useSwagger: true,
-        useGitHubActions: true,
-      };
-
-      mockPrompt.mockResolvedValue(mockAnswers);
-
-      await PromptsService.getProjectDetails();
-
-      const promptCall = mockPrompt.mock.calls[0][0];
-      const githubActionsPrompt = promptCall.find(
-        (q: any) => q.name === 'useGitHubActions',
-      );
-
-      expect(githubActionsPrompt.default).toBe(true);
-    });
-
     it('should set database default to MySQL', async () => {
       const mockAnswers: ProjectAnswers = {
         packageManager: PackageManager.NPM,
         description: 'Test',
         author: '',
         useDocker: false,
-        useSwagger: true,
-        useGitHubActions: true,
       };
 
       mockPrompt.mockResolvedValue(mockAnswers);
@@ -309,8 +235,6 @@ describe('PromptsService', () => {
         description: 'Test',
         author: '',
         useDocker: false,
-        useSwagger: true,
-        useGitHubActions: true,
       };
 
       mockPrompt.mockResolvedValue(mockAnswers);
@@ -332,8 +256,6 @@ describe('PromptsService', () => {
           description: 'Test',
           author: '',
           useDocker: false,
-          useSwagger: true,
-          useGitHubActions: true,
         };
 
         mockPrompt.mockResolvedValue(mockAnswers);
@@ -352,8 +274,6 @@ describe('PromptsService', () => {
           author: '',
           useDocker: true,
           database: db,
-          useSwagger: true,
-          useGitHubActions: true,
         };
 
         mockPrompt.mockResolvedValue(mockAnswers);
@@ -370,8 +290,6 @@ describe('PromptsService', () => {
         description: 'Test',
         author: '',
         useDocker: false,
-        useSwagger: true,
-        useGitHubActions: true,
       };
 
       mockPrompt.mockResolvedValue(mockAnswers);
@@ -389,8 +307,6 @@ describe('PromptsService', () => {
         author: '',
         useDocker: true,
         database: Database.POSTGRES,
-        useSwagger: true,
-        useGitHubActions: true,
       };
 
       mockPrompt.mockResolvedValue(mockAnswers);

--- a/src/services/file-generator.service.ts
+++ b/src/services/file-generator.service.ts
@@ -33,7 +33,6 @@ export class FileGeneratorService {
         name,
         answers.description,
         answers.author,
-        answers.useSwagger,
         answers.database,
       ),
     );
@@ -60,10 +59,7 @@ export class FileGeneratorService {
     const srcPath = path.join(projectPath, 'src');
 
     // Main application files
-    fs.writeFileSync(
-      path.join(srcPath, 'main.ts'),
-      createMainTs(answers.useSwagger),
-    );
+    fs.writeFileSync(path.join(srcPath, 'main.ts'), createMainTs());
     fs.writeFileSync(path.join(srcPath, 'app.module.ts'), createAppModule());
     fs.writeFileSync(
       path.join(srcPath, 'app.controller.ts'),
@@ -140,8 +136,6 @@ export class FileGeneratorService {
   }
 
   static generateGitHubActionsFiles(config: ProjectConfig): void {
-    if (!config.answers.useGitHubActions) return;
-
     const workflowsPath = path.join(config.path, '.github/workflows');
     fs.ensureDirSync(workflowsPath);
 
@@ -158,7 +152,6 @@ export class FileGeneratorService {
       config.answers.description,
       config.answers.packageManager,
       config.answers.useDocker,
-      config.answers.useGitHubActions,
     );
 
     fs.writeFileSync(path.join(config.path, 'README.md'), readmeContent);
@@ -168,7 +161,6 @@ export class FileGeneratorService {
     await PackageInstallerService.install(
       config.path,
       config.answers.packageManager,
-      config.answers.useSwagger,
       config.answers.database,
     );
   }

--- a/src/services/package-installer.service.ts
+++ b/src/services/package-installer.service.ts
@@ -7,19 +7,16 @@ import { PackageManager, Database } from '../constants/enums';
 const execAsync = promisify(exec);
 
 export class PackageInstallerService {
-  static getDependencies(useSwagger: boolean, database?: Database): string[] {
+  static getDependencies(database?: Database): string[] {
     const dependencies = [
       '@nestjs/common',
       '@nestjs/core',
       '@nestjs/platform-express',
       '@nestjs/config',
+      '@nestjs/swagger',
       'reflect-metadata',
       'rxjs',
     ];
-
-    if (useSwagger) {
-      dependencies.push('@nestjs/swagger');
-    }
 
     // Add database-specific dependencies
     if (database === Database.MYSQL) {
@@ -86,13 +83,12 @@ export class PackageInstallerService {
   static async install(
     projectPath: string,
     packageManager: PackageManager,
-    useSwagger: boolean = true,
     database?: Database,
   ): Promise<void> {
     const spinner = ora('Installing dependencies...').start();
 
     try {
-      const dependencies = this.getDependencies(useSwagger, database);
+      const dependencies = this.getDependencies(database);
       const devDependencies = this.getDevDependencies();
 
       // Install regular dependencies

--- a/src/services/prompts.service.ts
+++ b/src/services/prompts.service.ts
@@ -40,18 +40,6 @@ export class PromptsService {
         default: Database.MYSQL,
         when: (answers) => answers.useDocker,
       },
-      {
-        type: 'confirm',
-        name: 'useSwagger',
-        message: 'Add Swagger documentation?',
-        default: true,
-      },
-      {
-        type: 'confirm',
-        name: 'useGitHubActions',
-        message: 'Add GitHub Actions for CI/CD?',
-        default: true,
-      },
     ]);
   }
 }

--- a/src/templates/main.template.ts
+++ b/src/templates/main.template.ts
@@ -1,39 +1,32 @@
-export function createMainTs(useSwagger: boolean): string {
-  const swaggerImport = useSwagger
-    ? `import { SwaggerModule, DocumentBuilder } from '@nestjs/swagger';\n`
-    : '';
-
-  const swaggerSetup = useSwagger
-    ? `
-    // Swagger documentation
-    const config = new DocumentBuilder()
-      .setTitle('API Documentation')
-      .setDescription('The API description')
-      .setVersion('1.0')
-      .addTag('api')
-      .build();
-    const document = SwaggerModule.createDocument(app, config);
-    SwaggerModule.setup('api', app, document);
-  `
-    : '';
-
+export function createMainTs(): string {
   return `import { NestFactory } from '@nestjs/core';
-  ${swaggerImport}import { AppModule } from './app.module';
+import { SwaggerModule, DocumentBuilder } from '@nestjs/swagger';
+import { AppModule } from './app.module';
+
+async function bootstrap() {
+  const app = await NestFactory.create(AppModule);
   
-  async function bootstrap() {
-    const app = await NestFactory.create(AppModule);
-    
-    // Enable CORS
-    app.enableCors();
-    
-    // Global prefix
-    app.setGlobalPrefix('api');
-  ${swaggerSetup}
-    const port = process.env.PORT || 3000;
-    await app.listen(port);
-    console.log(\`Application is running on: http://localhost:\${port}\`);
-    ${useSwagger ? 'console.log(\`Swagger docs available at: http://localhost:\${port}/api\`);' : ''}
-  }
-  bootstrap();
-  `;
+  // Enable CORS
+  app.enableCors();
+  
+  // Global prefix
+  app.setGlobalPrefix('api');
+
+  // Swagger documentation
+  const config = new DocumentBuilder()
+    .setTitle('API Documentation')
+    .setDescription('The API description')
+    .setVersion('1.0')
+    .addTag('api')
+    .build();
+  const document = SwaggerModule.createDocument(app, config);
+  SwaggerModule.setup('api', app, document);
+
+  const port = process.env.PORT || 3000;
+  await app.listen(port);
+  console.log(\`Application is running on: http://localhost:\${port}\`);
+  console.log(\`Swagger docs available at: http://localhost:\${port}/api\`);
+}
+bootstrap();
+`;
 }

--- a/src/templates/package-json.template.ts
+++ b/src/templates/package-json.template.ts
@@ -3,7 +3,6 @@ export function createPackageJson(
   projectName: string,
   description: string,
   author: string,
-  useSwagger: boolean = true,
   database?: string,
 ): string {
   const packageJson = {

--- a/src/templates/readme.template.ts
+++ b/src/templates/readme.template.ts
@@ -5,7 +5,6 @@ export const createReadme = (
   description: string,
   packageManager: 'npm' | 'yarn' | 'pnpm',
   useDocker: boolean,
-  useGitHubActions: boolean,
 ): string => {
   const installCommand =
     packageManager === 'yarn'
@@ -26,17 +25,6 @@ docker-compose up -d
 \`\`\`
 
 ### Without Docker
-
-`
-    : '';
-
-  const cicdSection = useGitHubActions
-    ? `## CI/CD
-
-This project includes GitHub Actions workflows for:
-- Automated testing on push and pull requests
-- Code quality checks (linting, formatting)
-- Test coverage reporting
 
 `
     : '';
@@ -77,7 +65,14 @@ ${packageManager} run test:e2e
 ${packageManager} run test:cov
 \`\`\`
 
-${cicdSection}---
+## CI/CD
+
+This project includes GitHub Actions workflows for:
+- Automated testing on push and pull requests
+- Code quality checks (linting, formatting)
+- Test coverage reporting
+
+---
 Generated with nestify 
 `;
 };

--- a/src/types/project.types.ts
+++ b/src/types/project.types.ts
@@ -6,8 +6,6 @@ export interface ProjectAnswers {
   author: string;
   useDocker: boolean;
   database?: Database;
-  useSwagger: boolean;
-  useGitHubActions: boolean;
 }
 
 export interface NewCommandOptions {

--- a/src/utils/console-messages.ts
+++ b/src/utils/console-messages.ts
@@ -32,19 +32,13 @@ export class ConsoleMessages {
     this.showStartCommand(config, stepNumber);
 
     // Additional features info
-    if (config.answers.useSwagger) {
-      console.log(
-        chalk.cyan('\n📚 Swagger documentation will be available at:'),
-      );
-      console.log(chalk.white('   http://localhost:3000/api'));
-    }
 
-    if (config.answers.useGitHubActions) {
-      console.log(chalk.cyan('\n🚀 GitHub Actions workflows added:'));
-      console.log(
-        chalk.white('   - .github/workflows/tests.yml (automated testing)'),
-      );
-    }
+    console.log(chalk.cyan('\n📚 Swagger documentation will be available at:'));
+    console.log(chalk.white('   http://localhost:3000/api'));
+    console.log(chalk.cyan('\n🚀 GitHub Actions workflows added:'));
+    console.log(
+      chalk.white('   - .github/workflows/tests.yml (automated testing)'),
+    );
 
     console.log(chalk.cyan('\n🎉 Happy coding!'));
     console.log(chalk.yellow('\n☕ Enjoying nestify? Buy me a coffee:'));


### PR DESCRIPTION
Remove `useSwagger` and `useGitHubActions` fields from project generation flow. This includes:

- Removed fields from ProjectAnswers interface and all related tests
- Updated PackageInstallerService.install() to remove useSwagger parameter
- Cleaned up prompts and validation logic for these deprecated options
- Removed related test cases and mock data

These options are no longer needed in the project scaffolding workflow, simplifying the configuration process for new projects.